### PR TITLE
feat/slider 초기 이미지 보일때 애니메이션 적용 안하도록 변경, 이미지 첫 번째, 마지막인지 따라 화살표 보여주기

### DIFF
--- a/client/src/components/Animation/Slider/Slider.style.ts
+++ b/client/src/components/Animation/Slider/Slider.style.ts
@@ -18,7 +18,7 @@ export const SlideBox = styled.div`
 
 export const ProductDetailImg = styled(motion.img)`
   width: 100%;
-  height: 300px;
+  height: 450px;
   border-radius: 10px;
   @media screen and (max-width: 860px) {
     width: 290px;

--- a/client/src/components/Animation/Slider/Slider.tsx
+++ b/client/src/components/Animation/Slider/Slider.tsx
@@ -27,9 +27,8 @@ export default function Slider() {
       },
     },
     exit: (isBack: boolean) => ({
-      x: isBack ? 500 : -500,
       opacity: 0,
-      scale: 0,
+
       transition: {
         duration: 0.5,
       },

--- a/client/src/components/Animation/Slider/Slider.tsx
+++ b/client/src/components/Animation/Slider/Slider.tsx
@@ -6,6 +6,7 @@ import * as S from "./Slider.style";
 export default function Slider() {
   const [visible, setVisible] = useState<number>(0);
   const [back, setBack] = useState<boolean>(false);
+  const arrowIconSize = 23;
 
   const images = [
     "https://t4.ftcdn.net/jpg/06/34/00/69/240_F_634006945_eGQCGQrinCG5nVmhUtZ0LumH9EoGFoDt.jpg",
@@ -13,10 +14,9 @@ export default function Slider() {
     "https://t3.ftcdn.net/jpg/04/31/72/70/240_F_431727023_tgAI6ORGvruHGQmP1sXnHkAHR1fwb7cK.jpg",
   ];
   const boxVairants = {
-    entry: (isBack: boolean) => ({
-      x: isBack ? -500 : 500,
+    entry: () => ({
+      x: 0,
       opacity: 0,
-      scale: 0,
     }),
     center: {
       x: 0,
@@ -53,7 +53,7 @@ export default function Slider() {
 
   return (
     <S.SlideBox>
-      <AiOutlineLeft size={18} onClick={previousPlease} />
+      {visible > 0 ? <AiOutlineLeft size={arrowIconSize} onClick={previousPlease} /> : null}
       <AnimatePresence mode="wait" custom={back}>
         {images.map((image, idx) =>
           idx === visible ? (
@@ -82,8 +82,7 @@ export default function Slider() {
           ) : null
         )}
       </AnimatePresence>
-
-      <AiOutlineRight size={18} onClick={nextPlease} />
+      {visible !== images.length - 1 ? <AiOutlineRight size={arrowIconSize} onClick={nextPlease} /> : null}
     </S.SlideBox>
   );
 }

--- a/client/src/pages/ProductDetail/ProductDetail.style.ts
+++ b/client/src/pages/ProductDetail/ProductDetail.style.ts
@@ -10,7 +10,7 @@ export const ProductDetailBox = styled.div`
 `;
 
 export const ProductDetailLayout = styled.div`
-  max-width: 420px;
+  max-width: 680px;
   @media screen and (max-width: 860px) {
     max-width: 290px;
   }
@@ -60,8 +60,8 @@ export const ProductDetailViewBox = styled(ProductDetailProfileBox)`
 export const ProductDetailBtn = styled.button`
   cursor: pointer;
   display: flex;
-  /* width: 150px; */
-  width: 100%;
+  width: 150px;
+  /* width: 100%; */
   height: 50px;
   justify-content: center;
   align-items: center;


### PR DESCRIPTION
1. 첫 번째 이미지일때 좌측 화살표 안보여주고, 마지막 이미지 이면 우측 화살표 보이도록 수정.
2. 업로드 컴포넌트 폼 너비를 상품 상세페이지 너비 같은 크기로 수정.

https://github.com/SonMinSeock/ikw-market/assets/44064257/2a938629-5f8f-4546-9df9-85a70eabc3d1

